### PR TITLE
Fix: Use relative path for main.tsx in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,6 @@
   <body class="bg-neutral-900">
     <div id="root"></div>
     <!-- Vite injeta o JS/CSS aqui -->
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
I changed the script source for main.tsx from an absolute path (/src/main.tsx) to a relative path (./src/main.tsx) in index.html.

This allows Vite to correctly process and inject the appropriate script tag during the build process, resolving the 404 error for main.tsx in production environments.